### PR TITLE
fix: snacks marker list

### DIFF
--- a/lua/marker-groups/pickers/snacks.lua
+++ b/lua/marker-groups/pickers/snacks.lua
@@ -4,6 +4,21 @@ local groups = require "marker-groups.groups"
 local state = require "marker-groups.state"
 local utils = require "marker-groups.pickers.utils"
 
+local function with_modifiable(buf, fn)
+  if not (buf and vim.api.nvim_buf_is_valid(buf)) then
+    return false
+  end
+  local prev = vim.bo[buf].modifiable
+  if not prev then
+    vim.bo[buf].modifiable = true
+  end
+  local ok, err = pcall(fn)
+  if not prev then
+    vim.bo[buf].modifiable = false
+  end
+  return ok, err
+end
+
 function M.show_groups(opts)
   opts = opts or {}
   local ok, snacks = pcall(require, "snacks")
@@ -47,21 +62,6 @@ function M.show_groups(opts)
       end
     end
     return nil
-  end
-
-  local function with_modifiable(buf, fn)
-    if not (buf and vim.api.nvim_buf_is_valid(buf)) then
-      return false
-    end
-    local prev = vim.bo[buf].modifiable
-    if not prev then
-      vim.bo[buf].modifiable = true
-    end
-    local ok, err = pcall(fn)
-    if not prev then
-      vim.bo[buf].modifiable = false
-    end
-    return ok, err
   end
 
   snacks.picker {
@@ -144,12 +144,22 @@ function M.show_markers(opts)
   for _, m in ipairs(markers) do
     local file_name = vim.fn.fnamemodify(m.buffer_path, ":t")
     local line_info = m.start_line ~= m.end_line and (m.start_line .. "-" .. m.end_line) or m.start_line
-    table.insert(items, { text = string.format("%-20s %4s: %s", file_name, line_info, m.annotation), marker = m })
+    table.insert(items, {
+      text = string.format("%-20s %4s: %s", file_name, line_info, m.annotation),
+      file = m.buffer_path,
+      marker = m,
+    })
   end
 
   snacks.picker {
-    source = { name = "marker_list", items = items },
+    source = "marker_list",
+    items = items,
     prompt = "Markers - " .. active .. "> ",
+    format = function(item)
+      local ret = {}
+      ret[#ret + 1] = { item.text }
+      return ret
+    end,
     preview = function(ctx)
       local m = ctx.item and ctx.item.marker
       if not m then
@@ -162,7 +172,18 @@ function M.show_markers(opts)
       end)
       return true
     end,
-    actions = {},
+    actions = {
+      confirm = function(picker, item)
+        local m = item and item.marker
+        if not m then
+          return
+        end
+        utils.navigate_to_marker(m)
+        if picker and picker.close then
+          picker:close()
+        end
+      end,
+    },
   }
 end
 

--- a/lua/marker-groups/pickers/utils.lua
+++ b/lua/marker-groups/pickers/utils.lua
@@ -94,8 +94,11 @@ end
 function M.navigate_to_marker(marker)
   local ok, err = pcall(function()
     vim.cmd("edit " .. vim.fn.fnameescape(marker.buffer_path))
-    vim.api.nvim_win_set_cursor(0, { marker.start_line, 0 })
-    vim.cmd "normal! zz"
+    -- Schedule cursor positioning after buffer loads
+    vim.schedule(function()
+      vim.api.nvim_win_set_cursor(0, { marker.start_line, 0 })
+      vim.cmd "normal! zz"
+    end)
   end)
   if ok then
     require("marker-groups.feedback").notify(


### PR DESCRIPTION
## Description
This PR fixes a few issues I was having with the snacks picker implementation, particularly when calling `show_markers`.

1. Move `with_modifiable` out to be used by both `show_groups` and `show_markers`
2. Add the file path to the picker items table
3. Add a confirm action that calls `navigate_to_marker`
4. Update `navigate_to_marker` to schedule the line jump for after the file is finished opening

## Type of Change
- [x] Bug fix (non-breaking change which fixes an issue)

## Testing
- [x] I have tested these changes locally
- [x] All existing tests pass

## Checklist
- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] My changes generate no new warnings