### PR TITLE
fix: replace deprecated vim.tbl_flatten

### DIFF
--- a/lua/marker-groups/persistence.lua
+++ b/lua/marker-groups/persistence.lua
@@ -332,13 +332,15 @@ function M.load()
     vim.g.__marker_groups_hydrating = false
   end, 300)
 
+  local marker_lists = vim.tbl_values(vim.tbl_map(function(g)
+    return g.markers
+  end, data.marker_groups))
+
   return {
     success = true,
     source = source_file,
     groups_loaded = vim.tbl_count(data.marker_groups),
-    markers_loaded = vim.tbl_count(vim.tbl_flatten(vim.tbl_map(function(g)
-      return g.markers
-    end, data.marker_groups))),
+    markers_loaded = vim.tbl_count(vim.iter(marker_lists):flatten():totable()),
   }
 end
 

--- a/lua/marker-groups/state.lua
+++ b/lua/marker-groups/state.lua
@@ -401,14 +401,19 @@ function M.reset()
   next_extmark_id = 1
 end
 
+local function count_all_markers(groups)
+  local lists = vim.tbl_values(vim.tbl_map(function(g)
+    return g.markers
+  end, groups))
+  return vim.tbl_count(vim.iter(lists):flatten():totable())
+end
+
 function M.debug_info()
   return {
     state_initialized = state ~= nil,
     active_group = state and state.active_group or nil,
     group_count = state and vim.tbl_count(state.marker_groups) or 0,
-    total_markers = state and vim.tbl_count(vim.tbl_flatten(vim.tbl_map(function(g)
-      return g.markers
-    end, state.marker_groups))) or 0,
+    total_markers = state and count_all_markers(state.marker_groups) or 0,
     event_listener_count = vim.tbl_count(event_listeners),
     next_extmark_id = next_extmark_id,
   }

--- a/tests/mini/unit/test_state.lua
+++ b/tests/mini/unit/test_state.lua
@@ -387,4 +387,21 @@ T["core functionality verification / can delete all markers in a marker group an
   vim.api.nvim_buf_delete(test_buf, { force = true })
 end
 
+T["debug_info total_markers avoids deprecated tbl_flatten"] = function()
+  local state = require "marker-groups.state"
+  state.create_group "g2"
+  state.add_marker({ buffer_path = "/tmp/a.lua", start_line = 1, end_line = 1, annotation = "a" }, "default")
+  state.add_marker({ buffer_path = "/tmp/b.lua", start_line = 2, end_line = 2, annotation = "b" }, "g2")
+  local seen = false
+  local orig = vim.deprecate
+  vim.deprecate = function(...)
+    seen = true
+    return orig(...)
+  end
+  local info = state.debug_info()
+  vim.deprecate = orig
+  MiniTest.expect.equality(2, info.total_markers)
+  MiniTest.expect.equality(false, seen)
+end
+
 return T


### PR DESCRIPTION
Replaces vim.tbl_flatten (deprecated, removed in Nvim 0.13) with vim.iter():flatten():totable() in the two marker-count paths. Also corrects the counts, which returned 0 because tbl_flatten ignores string-keyed tables. Runtime only; no schema change.

Closes #15.