### PR TITLE
fix: snacks marker picker navigates on confirm

### DIFF
--- a/lua/marker-groups/pickers/snacks.lua
+++ b/lua/marker-groups/pickers/snacks.lua
@@ -4,6 +4,21 @@ local groups = require "marker-groups.groups"
 local state = require "marker-groups.state"
 local utils = require "marker-groups.pickers.utils"
 
+local function with_modifiable(buf, fn)
+  if not (buf and vim.api.nvim_buf_is_valid(buf)) then
+    return false
+  end
+  local prev = vim.bo[buf].modifiable
+  if not prev then
+    vim.bo[buf].modifiable = true
+  end
+  local ok, err = pcall(fn)
+  if not prev then
+    vim.bo[buf].modifiable = false
+  end
+  return ok, err
+end
+
 function M.show_groups(opts)
   opts = opts or {}
   local ok, snacks = pcall(require, "snacks")
@@ -47,21 +62,6 @@ function M.show_groups(opts)
       end
     end
     return nil
-  end
-
-  local function with_modifiable(buf, fn)
-    if not (buf and vim.api.nvim_buf_is_valid(buf)) then
-      return false
-    end
-    local prev = vim.bo[buf].modifiable
-    if not prev then
-      vim.bo[buf].modifiable = true
-    end
-    local ok, err = pcall(fn)
-    if not prev then
-      vim.bo[buf].modifiable = false
-    end
-    return ok, err
   end
 
   snacks.picker {
@@ -144,12 +144,20 @@ function M.show_markers(opts)
   for _, m in ipairs(markers) do
     local file_name = vim.fn.fnamemodify(m.buffer_path, ":t")
     local line_info = m.start_line ~= m.end_line and (m.start_line .. "-" .. m.end_line) or m.start_line
-    table.insert(items, { text = string.format("%-20s %4s: %s", file_name, line_info, m.annotation), marker = m })
+    table.insert(items, {
+      text = string.format("%-20s %4s: %s", file_name, line_info, m.annotation),
+      file = m.buffer_path,
+      marker = m,
+    })
   end
 
   snacks.picker {
-    source = { name = "marker_list", items = items },
+    source = "marker_list",
+    items = items,
     prompt = "Markers - " .. active .. "> ",
+    format = function(item)
+      return { { tostring(item.text or "") } }
+    end,
     preview = function(ctx)
       local m = ctx.item and ctx.item.marker
       if not m then
@@ -162,7 +170,18 @@ function M.show_markers(opts)
       end)
       return true
     end,
-    actions = {},
+    actions = {
+      confirm = function(picker, item)
+        local m = item and item.marker
+        if not m then
+          return
+        end
+        utils.navigate_to_marker(m)
+        if picker and picker.close then
+          picker:close()
+        end
+      end,
+    },
   }
 end
 

--- a/lua/marker-groups/pickers/utils.lua
+++ b/lua/marker-groups/pickers/utils.lua
@@ -94,8 +94,10 @@ end
 function M.navigate_to_marker(marker)
   local ok, err = pcall(function()
     vim.cmd("edit " .. vim.fn.fnameescape(marker.buffer_path))
-    vim.api.nvim_win_set_cursor(0, { marker.start_line, 0 })
-    vim.cmd "normal! zz"
+    vim.schedule(function()
+      vim.api.nvim_win_set_cursor(0, { marker.start_line, 0 })
+      vim.cmd "normal! zz"
+    end)
   end)
   if ok then
     require("marker-groups.feedback").notify(


### PR DESCRIPTION
Snacks show_markers had an empty actions table, so selecting a marker did nothing. It also referenced with_modifiable out of scope, so its preview errored. Hoist with_modifiable to module scope, add a confirm action that navigates to the marker, and schedule the cursor jump after the buffer opens.

Incorporates the fix from @jhixson in #12.

Closes #12.