### PR TITLE
fix: add marker to focused window with splits

### DIFF
--- a/lua/marker-groups/commands.lua
+++ b/lua/marker-groups/commands.lua
@@ -154,6 +154,7 @@ function M.setup()
     local has_range = args.line1 and args.line2 and args.line1 ~= args.line2
     local range_start = has_range and math.min(args.line1, args.line2) or nil
     local range_end = has_range and math.max(args.line1, args.line2) or nil
+    local target_buf = vim.api.nvim_get_current_buf()
 
     if annotation == "" then
       local input_ui = require "marker-groups.ui.input"
@@ -164,9 +165,9 @@ function M.setup()
           if input and input ~= "" then
             local result
             if range_start and range_end then
-              result = markers.add_marker_range(range_start, range_end, input)
+              result = markers.add_marker_range(range_start, range_end, input, nil, target_buf)
             end
-            result = result or markers.add_marker(input)
+            result = result or markers.add_marker(input, nil, target_buf)
             if not result.success then
               require("marker-groups.feedback").notify(
                 "Failed to add marker: " .. result.error,
@@ -182,9 +183,9 @@ function M.setup()
     else
       local result
       if range_start and range_end then
-        result = markers.add_marker_range(range_start, range_end, annotation)
+        result = markers.add_marker_range(range_start, range_end, annotation, nil, target_buf)
       else
-        result = markers.add_marker(annotation)
+        result = markers.add_marker(annotation, nil, target_buf)
       end
       if not result.success then
         require("marker-groups.feedback").notify("Failed to add marker: " .. result.error, vim.log.levels.ERROR, {})

--- a/lua/marker-groups/keymaps.lua
+++ b/lua/marker-groups/keymaps.lua
@@ -158,12 +158,13 @@ function M.setup()
         local ls = require "marker-groups.line_selection"
         local input_ui = require "marker-groups.ui.input"
         local range = ls.make_range()
+        local target_buf = vim.api.nvim_get_current_buf()
         input_ui.prompt_multiline(
           { title = "Marker annotation", default = "" },
           require("marker-groups.config").get_internal "max_annotation_chars",
           function(input)
             if input and input ~= "" then
-              local result = markers.add_marker_range(range.lstart, range.lend, input)
+              local result = markers.add_marker_range(range.lstart, range.lend, input, nil, target_buf)
               if not result.success then
                 require("marker-groups.feedback").notify(
                   "Failed to add marker: " .. result.error,

--- a/lua/marker-groups/markers.lua
+++ b/lua/marker-groups/markers.lua
@@ -6,8 +6,8 @@ local error_handling = require "marker-groups.error_handling"
 
 local ns_id = api.nvim_create_namespace "marker_groups"
 
-local function get_current_buffer_info()
-  local buf = api.nvim_get_current_buf()
+local function get_current_buffer_info(buf)
+  buf = buf or api.nvim_get_current_buf()
   local path = api.nvim_buf_get_name(buf)
 
   if path and path ~= "" and not vim.startswith(path, "/") then
@@ -22,8 +22,8 @@ local function get_line_range()
   return selection.lstart, selection.lend
 end
 
-function M.add_marker_range(start_line, end_line, annotation, group_name)
-  local buf, path = get_current_buffer_info()
+function M.add_marker_range(start_line, end_line, annotation, group_name, target_buf)
+  local buf, path = get_current_buffer_info(target_buf)
 
   if not api.nvim_buf_is_valid(buf) then
     return state.Result.error("Invalid buffer", "INVALID_BUFFER")
@@ -115,8 +115,8 @@ local function validate_buffer(buf, path)
   return true, nil
 end
 
-function M.add_marker(annotation, group_name)
-  local buf, path = get_current_buffer_info()
+function M.add_marker(annotation, group_name, target_buf)
+  local buf, path = get_current_buffer_info(target_buf)
 
   local valid, error_msg = validate_buffer(buf, path)
   if not valid then

--- a/scripts/ui_harness.sh
+++ b/scripts/ui_harness.sh
@@ -88,20 +88,21 @@ scenario_snacks_markers() {
     echo "NOTE: snacks show_markers produced no visible list (PR #12 territory)"
     cap
   fi
-  send Escape; send Escape
+  send Escape; sleep_ms 300; send Escape; sleep_ms 300
 }
 scenario_split_targeting() {
-  send Escape; send ":only" Enter
+  send Escape; sleep_ms 300
+  send ":only" Enter
   send ":vsplit scripts/ui_sandbox/init.lua" Enter
   wait_for "init.lua" 40
-  send "l"
   send ":wincmd l" Enter
-  send ":5" Enter
-  send ":MarkerAdd right window mark" Enter
-  wait_for "right window mark" 40
-  send ":lua vim.api.nvim_put({ '<<'..vim.api.nvim_buf_get_name(0):match('[^/]+$') }, 'c', true, false)" Enter
+  send ":3" Enter
+  send ":MarkerAdd focused split mark" Enter
+  wait_for "focused split mark" 40
+  send ":lua vim.api.nvim_put({'MGFILE='..vim.fn.fnamemodify(((require('marker-groups.markers').get_current_buffer_markers()[1] or {}).buffer_path or 'none'), ':t')}, 'l', true, false)" Enter
   send Escape
-  assert_screen "marker added in focused (right) buffer" "<<init.lua"
+  wait_for "MGFILE=fixture.lua" 40
+  assert_screen "marker recorded in focused buffer" "MGFILE=fixture.lua"
 }
 if [ "${1:-}" = "run" ] || [ -z "${BASH_SOURCE[1]:-}" ]; then
   start_nvim

--- a/tests/mini/integration/test_marker_window_target.lua
+++ b/tests/mini/integration/test_marker_window_target.lua
@@ -1,0 +1,39 @@
+local MiniTest = require "mini.test"
+local T = MiniTest.new_set {
+  hooks = {
+    pre_case = function()
+      for k in pairs(package.loaded) do
+        if k:match "^marker%-groups" then
+          package.loaded[k] = nil
+        end
+      end
+      require("marker-groups").setup {
+        data_dir = vim.fn.tempname() .. "_mg_wintarget",
+        keymaps = { enabled = false },
+      }
+    end,
+  },
+}
+
+T["add_marker_range targets the captured buffer not the current window"] = function()
+  local markers = require "marker-groups.markers"
+  local dir = vim.fn.tempname()
+  vim.fn.mkdir(dir, "p")
+  local right = dir .. "/right.lua"
+  local left = dir .. "/left.lua"
+  vim.fn.writefile({ "right one", "right two", "right three" }, right)
+  vim.fn.writefile({ "left one", "left two", "left three" }, left)
+
+  vim.cmd("edit " .. right)
+  local right_buf = vim.api.nvim_get_current_buf()
+  vim.cmd("vsplit " .. left)
+
+  local result = markers.add_marker_range(2, 2, "on right", nil, right_buf)
+
+  MiniTest.expect.equality(result.success, true)
+  MiniTest.expect.equality(result.value.buffer_path:match "right%.lua$" ~= nil, true)
+  MiniTest.expect.equality(result.value.buffer_path:match "left%.lua$" == nil, true)
+  pcall(vim.cmd, "only")
+end
+
+return T


### PR DESCRIPTION
Marker add resolved the buffer via nvim_get_current_buf() inside the async input callback, so with splits it targeted the wrong window after the input float closed. Capture the focused buffer at invocation and thread it through add_marker/add_marker_range. Adds a deterministic regression test and a state-based harness check.

Closes #14.