### PR TITLE
fix: wire documented marker picker keymaps

### DIFF
--- a/lua/marker-groups/config.lua
+++ b/lua/marker-groups/config.lua
@@ -46,6 +46,11 @@ local defaults = {
         info = { suffix = "i", desc = "Show marker at cursor" },
       },
 
+      picker = {
+        groups = { suffix = "tg", desc = "Open picker for marker groups" },
+        markers = { suffix = "tm", desc = "Open picker for markers" },
+      },
+
       group = {
         create = { suffix = "gc", desc = "Create marker group" },
         select = { suffix = "gs", desc = "Select marker group" },

--- a/lua/marker-groups/keymaps.lua
+++ b/lua/marker-groups/keymaps.lua
@@ -222,6 +222,26 @@ function M.setup()
   )
 
   map(
+    km.picker and km.picker.groups,
+    "n",
+    compute_lhs(prefix, km.picker and km.picker.groups),
+    safe_call(function()
+      return require("marker-groups.pickers").show_groups()
+    end, "Picker groups"),
+    "Open picker for marker groups"
+  )
+
+  map(
+    km.picker and km.picker.markers,
+    "n",
+    compute_lhs(prefix, km.picker and km.picker.markers),
+    safe_call(function()
+      return require("marker-groups.pickers").show_markers()
+    end, "Picker markers"),
+    "Open picker for markers"
+  )
+
+  map(
     km.marker and km.marker.delete,
     "n",
     compute_lhs(prefix, km.marker and km.marker.delete),
@@ -458,6 +478,26 @@ function M.defaults()
       end
     end, "Marker info"),
     "Show marker at cursor"
+  )
+
+  add(
+    km.picker and km.picker.groups,
+    "n",
+    compute_lhs(prefix, km.picker and km.picker.groups),
+    safe_call(function()
+      return require("marker-groups.pickers").show_groups()
+    end, "Picker groups"),
+    "Open picker for marker groups"
+  )
+
+  add(
+    km.picker and km.picker.markers,
+    "n",
+    compute_lhs(prefix, km.picker and km.picker.markers),
+    safe_call(function()
+      return require("marker-groups.pickers").show_markers()
+    end, "Picker markers"),
+    "Open picker for markers"
   )
 
   add(

--- a/tests/mini/unit/test_keymaps.lua
+++ b/tests/mini/unit/test_keymaps.lua
@@ -72,4 +72,32 @@ T["expected group keymaps exist"] = function()
   MiniTest.expect.equality(true, have[term "<leader>mgb"])
 end
 
+T["<leader>mtm triggers pickers.show_markers"] = function()
+  local called = { markers = false, groups = false }
+  package.loaded["marker-groups.pickers"] = {
+    show_markers = function()
+      called.markers = true
+    end,
+    show_groups = function()
+      called.groups = true
+    end,
+    delete_groups = function() end,
+  }
+  press "<leader>mtm"
+  MiniTest.expect.equality(true, called.markers)
+end
+
+T["<leader>mtg triggers pickers.show_groups"] = function()
+  local called = { markers = false, groups = false }
+  package.loaded["marker-groups.pickers"] = {
+    show_markers = function() end,
+    show_groups = function()
+      called.groups = true
+    end,
+    delete_groups = function() end,
+  }
+  press "<leader>mtg"
+  MiniTest.expect.equality(true, called.groups)
+end
+
 return T

--- a/tests/mini/unit/test_pickers_config.lua
+++ b/tests/mini/unit/test_pickers_config.lua
@@ -45,4 +45,16 @@ T["picker telescope maps to telescope or falls back"] = function()
   MiniTest.expect.equality(backend, expected)
 end
 
+T["telescope selected when its modules are present"] = function()
+  local had = telescope_available()
+  package.loaded["telescope"] = package.loaded["telescope"] or {}
+  package.loaded["telescope.pickers"] = package.loaded["telescope.pickers"] or {}
+  local backend = setup_with_picker "telescope"
+  if not had then
+    package.loaded["telescope"] = nil
+    package.loaded["telescope.pickers"] = nil
+  end
+  MiniTest.expect.equality(backend, "telescope")
+end
+
 return T


### PR DESCRIPTION
The README and docs advertised <leader>mtg and <leader>mtm for opening the group and marker pickers, but neither keymap was ever wired, so the picker keymap did nothing. Adds a picker keymap group (tg -> show_groups, tm -> show_markers) so the documented keys work, plus a test that telescope is selected when available. No doc change needed; the docs were already correct.

Closes #13.